### PR TITLE
Restore preview after selecting 'cancel' from the browser file dialog

### DIFF
--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -61,7 +61,12 @@ export default Component.extend({
    * @param  {Event} event The file change event
    */
   filesSelected: function(event) {
-    this.handleFiles(event.target.files);
+    var files = event.target.files;
+    if (files.length) {
+      this.handleFiles(files);
+    } else {
+      this.clearPreview();
+    }
   },
 
   handleFiles: function(files) {


### PR DESCRIPTION
I'm able to select a file from the browser file dialog. However, if I select 'cancel' from the browser file dialog when I try to change the image, the following error is thrown:

"TypeError: Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'."