### PR TITLE
Fix `readAs` options markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ It supports:
 * `progress` default `true`
 * `hideFileInput` default `true`
 * `readAs` default `readAsFile`
-	Options:
-		* readAsFile
-		* readAsArrayBuffer
-		* readAsBinaryString
-		* readAsDataURL
-		* readAsText
+	* `readAsFile`
+	* `readAsArrayBuffer`
+	* `readAsBinaryString`
+	* `readAsDataURL`
+	* `readAsText`
 
 ### Actions
 


### PR DESCRIPTION
Fix list markdown since they were just rendering as text instead of a list. Also wrapped options in code blocks.