### PR TITLE
Fix run loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-1.11.1
+    - env: EMBER_TRY_SCENARIO=ember-1.12.0
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -117,6 +117,38 @@ The addon provides the following classes to style the file-picker:
   * `.file-picker__dropzone`
   * `.file-picker__input`
 
+## Test helpers
+ember-cli-file-picker exports a test helper for acceptance tests.
+
+```js
+// tests/helpers/start-app.js
+import './ember-cli-file-picker';
+
+// tests/.jshintrc
+{
+  "predef": [
+    "uploadFile"
+  ]
+}
+
+// tests/acceptance/file-upload.js
+import { test } from 'qunit';
+import moduleForAcceptance from 'hoch1-catalog/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | file upload');
+
+test('visiting /file-upload', function(assert) {
+  visit('/file-upload');
+	const content = [
+	  '"var";"value"',
+		'"foo";"10"',
+		'"bar";"20"'
+	];
+	const filename = 'example.csv';
+	const lastModifiedDate = new Date();
+  uploadFile(content, filename, lastModifiedDate);
+});
+```
 
 ## Use with CarrierWave
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ import './ember-cli-file-picker';
 
 // tests/acceptance/file-upload.js
 import { test } from 'qunit';
-import moduleForAcceptance from 'hoch1-catalog/tests/helpers/module-for-acceptance';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
 
 moduleForAcceptance('Acceptance | file upload');
 

--- a/README.md
+++ b/README.md
@@ -139,13 +139,17 @@ moduleForAcceptance('Acceptance | file upload');
 
 test('visiting /file-upload', function(assert) {
   visit('/file-upload');
-	const content = [
-	  '"var";"value"',
-		'"foo";"10"',
-		'"bar";"20"'
-	];
-	const filename = 'example.csv';
-	const lastModifiedDate = new Date();
+
+  // content is passed to [Blob() constructor](https://developer.mozilla.org/de/docs/Web/API/Blob/Blob)
+  const content = [
+    '"var";"value"\n',
+    '"foo";"10"\n',
+    '"bar";"20"'
+  ];
+  const filename = 'example.csv';
+  const lastModifiedDate = new Date();
+
+  // all arguments are optional
   uploadFile(content, filename, lastModifiedDate);
 });
 ```

--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -165,9 +165,9 @@ export default Component.extend({
         });
       };
 
-      reader.onprogress = (event) => {
+      reader.onprogress = Ember.run.bind(this, (event) => {
         this.set('progressValue', event.loaded / event.total * 100);
-      };
+      });
 
       reader[readAs](file);
     });

--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+});

--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Controller.extend({
-});

--- a/blueprints/ember-cli-file-picker/index.js
+++ b/blueprints/ember-cli-file-picker/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('blob');
+  }
+};

--- a/bower.json
+++ b/bower.json
@@ -11,5 +11,8 @@
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
+  },
+  "devDependencies": {
+    "blob": "*"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,5 +14,7 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
+  app.import('bower_components/blob/Blob.js');
+
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -2,5 +2,14 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-cli-file-picker'
+  name: 'ember-cli-file-picker',
+
+  included: function included(app) {
+    this._super.included(app);
+
+    var isProduction = app.env === 'production';
+    if (!isProduction) {
+      app.import(app.bowerDirectory + '/blob/Blob.js', { type: 'test' });
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-truth-helpers": "1.2.0",
     "ember-try": "~0.1.2"
   },
   "dependencies": {

--- a/test-support/helpers/ember-cli-file-picker.js
+++ b/test-support/helpers/ember-cli-file-picker.js
@@ -1,6 +1,8 @@
-import Ember from 'ember';
 /* global Blob, jQuery */
-const uploadFileHelper = function(app, content, name, lastModifiedDate) {
+
+import Ember from 'ember';
+
+const uploadFileHelper = function(content, name, lastModifiedDate) {
   const file = new Blob(
     content ? content : ['']
   );
@@ -10,12 +12,25 @@ const uploadFileHelper = function(app, content, name, lastModifiedDate) {
   event.target = {
     files: [file]
   };
+
   Ember.run(() => {
     this.$('.file-picker__input').trigger(event);
   });
 };
 
-const uploadFile = Ember.Test.registerAsyncHelper('uploadFile', uploadFileHelper);
+const uploadFile = Ember.Test.registerAsyncHelper('uploadFile', function(app, content, name, lastModifiedDate) {
+  const file = new Blob(
+    content ? content : ['']
+  );
+  file.name = name ? name : '';
+  file.lastModifiedDate = lastModifiedDate ? lastModifiedDate : new Date();
+
+  return triggerEvent(
+    '.file-picker__input',
+    'change',
+    { target: { files: [file] } }
+  );
+});
 
 export { uploadFile };
 export { uploadFileHelper };

--- a/test-support/helpers/ember-cli-file-picker.js
+++ b/test-support/helpers/ember-cli-file-picker.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+/* global Blob, jQuery */
+const uploadFileHelper = function(app, content, name, lastModifiedDate) {
+  const file = new Blob(
+    content ? content : ['']
+  );
+  file.name = name ? name : '';
+  file.lastModifiedDate = lastModifiedDate ? lastModifiedDate : new Date();
+  const event = jQuery.Event('change');
+  event.target = {
+    files: [file]
+  };
+  Ember.run(() => {
+    this.$('.file-picker__input').trigger(event);
+  });
+};
+
+const uploadFile = Ember.Test.registerAsyncHelper('uploadFile', uploadFileHelper);
+
+export { uploadFile };
+export { uploadFileHelper };

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "uploadFile"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,35 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | index');
+
+test('Works for readAsFile', function(assert) {
+  visit('/');
+
+  uploadFile(
+    ['file content'],
+    'file.name'
+  );
+
+  andThen(function() {
+    assert.equal(find('dl .size').text(), 'file content'.length);
+    assert.equal(find('dl .name').text(), 'file.name');
+  });
+});
+
+test('Works for readAsText', function(assert) {
+  visit('/');
+
+  fillIn('select', 'readAsText');
+
+  uploadFile(
+    ['file content'],
+    'file.name'
+  );
+
+  andThen(function() {
+    assert.equal(find('dl .size').text(), 'file content'.length);
+    assert.equal(find('dl .name').text(), 'file.name');
+    assert.equal(find('dl .data').text(), 'file content');
+  });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    fileLoaded(file) {
+      this.set('data', file.data);
+      this.set('loaded', true);
+      this.set('name', file.name);
+      this.set('size', file.size);
+    }
+  },
+  data: null,
+  loaded: false,
+  name: null,
+  readAs: 'readAsFile',
+  readAsValues: [
+    'readAsFile',
+    'readAsArrayBuffer',
+    'readAsBinaryString',
+    'readAsDataUrl',
+    'readAsText'
+  ],
+  size: null
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,21 @@
 <h2 id="title">Welcome to Ember</h2>
 
-{{#file-picker fileLoaded="fileLoaded"}}
+<select onchange={{action (mut readAs) value="target.value"}}>
+  {{#each readAsValues as |readAsValue|}}
+    <option value={{readAsValue}} selected={{eq readAsValue readAs}}>{{readAsValue}}</option>
+  {{/each}}
+</select>
+
+{{#file-picker fileLoaded="fileLoaded" readAs=readAs}}
     Drag here or click to upload a file
 {{/file-picker}}
+
+{{#if loaded}}
+  <dl>
+    <dt>name</dt><dd class="name">{{name}}</dd>
+    <dt>size</dt><dd class="size">{{size}}</dd>
+    {{#if (eq readAs 'readAsText')}}
+      <dt>data</dt><dd class="data">{{data}}</dd>
+    {{/if}}
+  </dl>
+{{/if}}

--- a/tests/integration/components/file-picker-test.js
+++ b/tests/integration/components/file-picker-test.js
@@ -1,0 +1,13 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { uploadFileHelper } from '../../helpers/ember-cli-file-picker';
+
+moduleForComponent('file-picker', 'Integration | Component | file picker', {
+  integration: true
+});
+
+test('it\'s testable', function(assert) {
+  assert.expect(0);
+  this.render(hbs`{{file-picker}}`);
+  uploadFileHelper();
+});


### PR DESCRIPTION
Digging deeper into https://github.com/funkensturm/ember-cli-file-picker/issues/24#issuecomment-178667946 I found an auto run loop in ember-cli-file-picker which causes the exception in integration / acceptance test.

I'm not so familiar with ember run loop. So not sure if wrapping in `Ember.run` is the correct way to fix it.

I put failing test and fix into separate commits for demonstration purposes. Could squash them together before merge.