### PR TITLE
Don't accept drag/drop if dropzone is false

### DIFF
--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -211,39 +211,47 @@ export default Component.extend({
   },
   /* Drag'n'Drop events */
   dragOver: function(event) {
-    if (event.preventDefault) {
-      event.preventDefault();
+    if (this.get('dropzone') === true) {
+      if (event.preventDefault) {
+        event.preventDefault();
+      }
+      event.dataTransfer.dropEffect = 'copy';
     }
-    event.dataTransfer.dropEffect = 'copy';
   },
   drop: function(event) {
-    if (event.preventDefault) {
-      event.preventDefault();
-    }
+    if (this.get('dropzone') === true) {
+      if (event.preventDefault) {
+        event.preventDefault();
+      }
 
-    this.handleFiles(event.dataTransfer.files);
-    this.set('count', 0);
-    this.$().removeClass('over');
+      this.handleFiles(event.dataTransfer.files);
+      this.set('count', 0);
+      this.$().removeClass('over');
+    }
   },
   dragEnter: function(event) {
-    if (event.preventDefault) {
-      event.preventDefault();
-    }
-    if (!this.get('multiple')) {
-      this.clearPreview();
-    }
-    var count = this.incrementProperty('count');
-    if (count === 1) {
-      this.$().addClass('over');
+    if (this.get('dropzone') === true) {
+      if (event.preventDefault) {
+        event.preventDefault();
+      }
+      if (!this.get('multiple')) {
+        this.clearPreview();
+      }
+      var count = this.incrementProperty('count');
+      if (count === 1) {
+        this.$().addClass('over');
+      }
     }
   },
   dragLeave: function(event) {
-    if (event.preventDefault) {
-      event.preventDefault();
-    }
-    var count = this.decrementProperty('count');
-    if (count === 0) {
-      this.$().removeClass('over');
+    if (this.get('dropzone') === true) {
+      if (event.preventDefault) {
+        event.preventDefault();
+      }
+      var count = this.decrementProperty('count');
+      if (count === 0) {
+        this.$().removeClass('over');
+      }
     }
   }
 });

--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -211,47 +211,54 @@ export default Component.extend({
   },
   /* Drag'n'Drop events */
   dragOver: function(event) {
-    if (this.get('dropzone') === true) {
-      if (event.preventDefault) {
-        event.preventDefault();
-      }
-      event.dataTransfer.dropEffect = 'copy';
+    if (event.preventDefault) {
+      event.preventDefault();
     }
+    if (!this.get('dropzone')) {
+      return;
+    }
+
+    event.dataTransfer.dropEffect = 'copy';
   },
   drop: function(event) {
-    if (this.get('dropzone') === true) {
-      if (event.preventDefault) {
-        event.preventDefault();
-      }
-
-      this.handleFiles(event.dataTransfer.files);
-      this.set('count', 0);
-      this.$().removeClass('over');
+    if (event.preventDefault) {
+      event.preventDefault();
     }
+    if (!this.get('dropzone')) {
+      return;
+    }
+
+    this.handleFiles(event.dataTransfer.files);
+    this.set('count', 0);
+    this.$().removeClass('over');
   },
   dragEnter: function(event) {
-    if (this.get('dropzone') === true) {
-      if (event.preventDefault) {
-        event.preventDefault();
-      }
-      if (!this.get('multiple')) {
-        this.clearPreview();
-      }
-      var count = this.incrementProperty('count');
-      if (count === 1) {
-        this.$().addClass('over');
-      }
+    if (event.preventDefault) {
+      event.preventDefault();
+    }
+    if (!this.get('dropzone')) {
+      return;
+    }
+
+    if (!this.get('multiple')) {
+      this.clearPreview();
+    }
+    var count = this.incrementProperty('count');
+    if (count === 1) {
+      this.$().addClass('over');
     }
   },
   dragLeave: function(event) {
-    if (this.get('dropzone') === true) {
-      if (event.preventDefault) {
-        event.preventDefault();
-      }
-      var count = this.decrementProperty('count');
-      if (count === 0) {
-        this.$().removeClass('over');
-      }
+    if (event.preventDefault) {
+      event.preventDefault();
+    }
+    if (!this.get('dropzone')) {
+      return;
+    }
+
+    var count = this.decrementProperty('count');
+    if (count === 0) {
+      this.$().removeClass('over');
     }
   }
 });


### PR DESCRIPTION
Use the `dropzone` parameter to enable/disable drag-n-drop, per https://github.com/funkensturm/ember-cli-file-picker/issues/32

Wrapped each of the dnd action handlers in a `if (this.get('dropzone') === true)` block.