### PR TITLE
Fixes #17

### DIFF
--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -24,6 +24,7 @@ export default Component.extend({
   preview: true,
   dropzone: true,
   progress: true,
+  showProgress: false,
   hideFileInput: true,
   readAs: 'readAsFile',
   selectOnClick: true,
@@ -106,7 +107,7 @@ export default Component.extend({
       // TODO
     } else {
       this.clearPreview();
-      this.$('.file-picker__progress').show();
+      this.set('showProgress', true);
 
       readFile(files[0], 'readAsDataURL', bind(this, 'updateProgress'))
         .then(bind(this, 'addPreviewImage'));
@@ -150,7 +151,7 @@ export default Component.extend({
   },
 
   hideProgress: function() {
-    this.$('.file-picker__progress').hide();
+    this.set('showProgress', false);
   },
 
   clearPreview: function() {
@@ -228,5 +229,18 @@ export default Component.extend({
     if (count === 0) {
       this.$().removeClass('over');
     }
-  }
+  },
+
+  /*
+   * returns true if browser supportes progress element
+   *
+   * browser support overview:
+   * http://caniuse.com/#feat=progress
+   *
+   * uses test from Modernizr
+   * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/elem/progress-meter.js
+   */
+  isProgressSupported: Ember.computed(function() {
+    return document.createElement('progress').max !== undefined;
+  })
 });

--- a/app/templates/components/file-picker.hbs
+++ b/app/templates/components/file-picker.hbs
@@ -11,9 +11,15 @@
 {{/if}}
 
 {{#if progress}}
-  <div class="file-picker__progress">
-    <span class="file-picker__progress__value" style={{progressStyle}}></span>
-  </div>
+  {{#if showProgress}}
+    {{#if isProgressSupported}}
+      <progress value={{progressValue}} max="100" class="file-picker__progress">{{progress}} %</progress>
+    {{else}}
+      <div class="file-picker__progress">
+        <span class="file-picker__progress__value" style={{progressStyle}}></span>
+      </div>
+    {{/if}}
+  {{/if}}
 {{/if}}
 
 {{input type="file" value=file accept=accept multiple=multiple class="file-picker__input"}}


### PR DESCRIPTION
Should be considered as a breaking change. Custom css to style layout bar is not used anymore in browsers that support `progress` element.