### PR TITLE
Fix(Input): Set input to null after select to fix webkit caching

### DIFF
--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -97,9 +97,8 @@ export default Component.extend({
       }
     }
 
-    var file_picker_input = this.$('.file-picker__input');
-    if (file_picker_input) {
-      file_picker_input.val(null);
+    if (!this.get('hideFileInput')) {
+      this.$('.file-picker__input').val(null);
     }
   },
 

--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -96,6 +96,8 @@ export default Component.extend({
           });
       }
     }
+
+    this.$('.file-picker__input').val(null);
   },
 
   /**

--- a/addon/components/file-picker.js
+++ b/addon/components/file-picker.js
@@ -97,7 +97,10 @@ export default Component.extend({
       }
     }
 
-    this.$('.file-picker__input').val(null);
+    var file_picker_input = this.$('.file-picker__input');
+    if (file_picker_input) {
+      file_picker_input.val(null);
+    }
   },
 
   /**

--- a/tests/unit/components/file-picker-test.js
+++ b/tests/unit/components/file-picker-test.js
@@ -91,5 +91,3 @@ test('it shows file input', function(assert) {
 
   assert.equal(component.$('input:hidden').length, 0);
 });
-
-

--- a/tests/unit/components/file-picker-test.js
+++ b/tests/unit/components/file-picker-test.js
@@ -80,14 +80,14 @@ test('it hides file input', function(assert) {
   assert.equal(component.$('input:hidden').length, 1);
 });
 
-test('it shows file input', function(assert) {
+test('it clears the file name', function(assert) {
   assert.expect(1);
 
-  const component = this.subject({
-    hideFileInput: false
-  });
-
+  const component = this.subject();
+  component.$('.file-picker__input').val('testfilename');
   this.render();
 
-  assert.equal(component.$('input:hidden').length, 0);
+  assert.equal(component.$('.file-picker__input').val(), null);
 });
+
+

--- a/tests/unit/components/file-picker-test.js
+++ b/tests/unit/components/file-picker-test.js
@@ -80,14 +80,16 @@ test('it hides file input', function(assert) {
   assert.equal(component.$('input:hidden').length, 1);
 });
 
-test('it clears the file name', function(assert) {
+test('it shows file input', function(assert) {
   assert.expect(1);
 
-  const component = this.subject();
-  component.$('.file-picker__input').val('testfilename');
+  const component = this.subject({
+    hideFileInput: false
+  });
+
   this.render();
 
-  assert.equal(component.$('.file-picker__input').val(), null);
+  assert.equal(component.$('input:hidden').length, 0);
 });
 
 


### PR DESCRIPTION
This fixes the problem of webkit not firing the change event on file selection via system dialog unless the filename changes.

[I have fought long and hard to put tests in place around this, but have finally given up since PhantomJS (I assume?) doesn't allow the filename to be preset. If anyone is able to add a test that proves this functionality, I'd really appreciate seeing how so I'm better armed next time...)
