### PR TITLE
Fixes "Cannot assign to read only property 'target' of object '#<Event>'"

### DIFF
--- a/test-support/helpers/ember-cli-file-picker.js
+++ b/test-support/helpers/ember-cli-file-picker.js
@@ -27,13 +27,9 @@ const uploadFileHelper = function(content, options) {
 };
 
 const uploadFile = Ember.Test.registerAsyncHelper('uploadFile', function(app, content, options) {
-  const file = createFile(content, options);
+  uploadFileHelper(content, options);
 
-  return triggerEvent(
-    '.file-picker__input',
-    'change',
-    { target: { files: [file] } }
-  );
+  return wait();
 });
 
 export { uploadFile };

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,41 +1,39 @@
-// TODO: readd as soon as it works reliable on Travis
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 
-// import { test } from 'qunit';
-// import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
-//
-// moduleForAcceptance('Acceptance | index');
-//
-// test('Works for readAsFile', function(assert) {
-//   visit('/');
-//
-//   uploadFile(
-//     ['file content'],
-//     {
-//       name: 'file.name'
-//     }
-//   );
-//
-//   andThen(function() {
-//     assert.equal(find('dl .size').text(), 'file content'.length);
-//     assert.equal(find('dl .name').text(), 'file.name');
-//   });
-// });
-//
-// test('Works for readAsText', function(assert) {
-//   visit('/');
-//
-//   fillIn('select', 'readAsText');
-//
-//   uploadFile(
-//     ['file content'],
-//     {
-//       name: 'file.name'
-//     }
-//   );
-//
-//   andThen(function() {
-//     assert.equal(find('dl .size').text(), 'file content'.length);
-//     assert.equal(find('dl .name').text(), 'file.name');
-//     assert.equal(find('dl .data').text(), 'file content');
-//   });
-// });
+moduleForAcceptance('Acceptance | index');
+
+test('Works for readAsFile', function(assert) {
+  visit('/');
+
+  uploadFile(
+    ['file content'],
+    {
+      name: 'file.name'
+    }
+  );
+
+  andThen(function() {
+    assert.equal(find('dl .size').text(), 'file content'.length);
+    assert.equal(find('dl .name').text(), 'file.name');
+  });
+});
+
+test('Works for readAsText', function(assert) {
+  visit('/');
+
+  fillIn('select', 'readAsText');
+
+  uploadFile(
+    ['file content'],
+    {
+      name: 'file.name'
+    }
+  );
+
+  andThen(function() {
+    assert.equal(find('dl .size').text(), 'file content'.length);
+    assert.equal(find('dl .name').text(), 'file.name');
+    assert.equal(find('dl .data').text(), 'file content');
+  });
+});


### PR DESCRIPTION
Details: https://github.com/funkensturm/ember-cli-file-picker/issues/34#issuecomment-268821905